### PR TITLE
MPICH: Fixed test generation

### DIFF
--- a/MPI/mpich-3.4.2/pcvs.setup
+++ b/MPI/mpich-3.4.2/pcvs.setup
@@ -8,14 +8,59 @@ subdir = sys.argv[1] if len(sys.argv) >= 2 else ''
 cur_srcdir = os.path.join(os.environ['pcvs_src'], subdir)
 cur_bldir = os.path.join(os.environ['pcvs_testbuild'], subdir)
 
+def arglist_to_str(arglist):
+    ret = ""
+    for arg in arglist[1:]:
+        ret = ret + "_" + arg
+    return ret
+
+def build_run_config_str(prefix, args, program):
+    if (1 > len(args)):
+        return ""
+    ret = """
+    run:
+        cwd: build/{prefix}/
+        program: 'build/{prefix}/{program}'
+        iterate:
+            n_mpi:
+                values: [ {mpi} ]
+    """.format(prefix=prefix, program=program, mpi=args[0])
+
+    if (1 >= len(args)):
+        return ret
+
+    run_arg = ""
+    for arg in args[1:]:
+        splitted = arg.split("=", 1)
+        if ("arg" == splitted[0]):
+            run_arg = run_arg + " " + splitted[1]
+
+    if (1 > len(run_arg)):
+        return ret
+
+    ret = """
+    run:
+        cwd: build/{prefix}/
+        program: 'build/{prefix}/{program}'
+        iterate:
+            n_mpi:
+                values: [ {mpi} ]
+            program:
+                run_arguments:
+                    type: 'argument'
+                    values: [ '{run_arg}' ]
+    """.format(prefix=prefix, program=program, mpi=args[0], run_arg=run_arg)
+
+    return ret
+
 def process_file(filename):
     try:
         srcfile = os.path.join(cur_srcdir, filename)
-        bldfile = os.path.join(cur_bldir, filename)
+        bldfile = os.path.join(cur_bldir, 'build', filename)
         if os.path.isfile(srcfile) and os.path.getsize(srcfile) > 0:
             filepath = os.path.join(cur_srcdir, filename)
-        elif os.path.isfile(bldfile) and os.path.gesize(bldfile) > 0:
-            filepath = os.path.join(cur_bldir, filename)
+        elif os.path.isfile(bldfile) and os.path.getsize(bldfile) > 0:
+            filepath = os.path.join(cur_bldir, 'build', filename)
         else:
             return
 
@@ -30,26 +75,25 @@ def process_file(filename):
                     continue
                 program = line.split()[0]
                 args = line.split()[1:]
+                test_args_str = arglist_to_str(args)
+                run_config_str = build_run_config_str(prefix, args, program)
                 if len(args) > 0:
                     print("""
-{escaped_prefix}{program}_np{mpi}:
+{escaped_prefix}{program}_np{mpi}_{args_str}:
     group: 'GRPMPI'
     build:
         depends_on: ['build_util', 'build_dtpools']
         files: '@BUILDPATH@/build/{prefix}/Makefile'
         make:
             target: '{program}'
-    run:
-        program: 'build/{prefix}/{program}'
-        iterate: 
-            n_mpi:
-                values: [ {mpi} ]
+    {run_config_str}
                 """.format(program=program,
+                           args_str=test_args_str,
                            prefix=prefix,
                            escaped_prefix=prefix.replace("/", "_"),
-                           mpi=args[0]))
-                elif (os.path.isdir(os.path.join(cur_srcdir, prefix, program))):
-                    process_file(os.path.join(cur_srcdir, prefix, program, 'testlist'))
+                           mpi=args[0], run_config_str=run_config_str))
+                elif (os.path.isdir(os.path.join(cur_srcdir, re.sub("^/", "", prefix), program))):
+                    process_file(os.path.join(cur_srcdir, re.sub("^/", "", prefix), program, 'testlist'))
                 else:
                     raise IOError
 


### PR DESCRIPTION
Fixes for the MPICH testsuite:

- Fixed build path so that PCVS correctly detects all test files
- Account for arguments defined in the `testlist` files when running the tests